### PR TITLE
Feat/user 유저 페이지에서 게시물 수 가져오기 (#34)

### DIFF
--- a/front/src/components/user/UserInfo.jsx
+++ b/front/src/components/user/UserInfo.jsx
@@ -8,7 +8,7 @@ import ProfileButton from "./ProfileButton";
 import { useNavigate } from "react-router-dom";
 import axiosInstance from "../../api/axiosInstance";
 
-function UserInfo({ user }) {
+function UserInfo({ user, postCount }) {
   const nav = useNavigate();
   const [isFollowing, setIsFollowing] = useState(false);
   const [followerCount, setFollowerCount] = useState(user.followerCount);
@@ -94,7 +94,7 @@ function UserInfo({ user }) {
             <Badge imageUrl={user.customDTO?.badgeDTO?.imageUrl} />
           </h2>
           <div className="stats">
-            <UserStat label="게시물" value={0} />
+            <UserStat label="게시물" value={postCount} />
             <UserStat
               label="팔로워"
               value={followerCount || 0}

--- a/front/src/components/user/UserPostGrid.jsx
+++ b/front/src/components/user/UserPostGrid.jsx
@@ -4,7 +4,7 @@ import "./UserPostGrid.css";
 import { useNavigate } from "react-router-dom";
 import PostDetailView from "../post/PostDetailView";
 
-function UserPostGrid({ userId }) {
+function UserPostGrid({ userId, onPostCountChange }) {
   const [posts, setPosts] = useState([]);
   const [modalOpen, setModalOpen] = useState(false);
   const [postId, setPostId] = useState(0);
@@ -22,11 +22,12 @@ function UserPostGrid({ userId }) {
       },
     })
       .then((result) => {
-        //console.log("posts", result.data.content);
+        //console.log("posts", result.data);
         setPosts(result.data.content);
+        onPostCountChange?.(result.data.totalElements);
       })
       .catch((err) => {
-        console.log(err);
+        //console.log(err);
 
         if (err.response?.status === 401 || err.response?.status === 403) {
             alert("로그인 후 이용해주세요.");

--- a/front/src/pages/user/UserPage.jsx
+++ b/front/src/pages/user/UserPage.jsx
@@ -10,6 +10,7 @@ function UserPage() {
   const { id } = useParams(); // /user/:id
   const nav = useNavigate();
   const loginUser = useSelector((state) => state.auth.user);
+  const [postCount, setPostCount] = useState(0);
 
   const [user, setUser] = useState({
     userId: "",
@@ -52,8 +53,8 @@ function UserPage() {
   return (
     <>
       <UserHeader user={targetUser} />
-      <UserInfo user={targetUser} />
-      <UserPostGrid userId={targetUser.userId} />
+      <UserInfo user={targetUser} postCount={postCount} />
+      <UserPostGrid userId={targetUser.userId} onPostCountChange={setPostCount} />
     </>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #34

## 📝작업 내용

> 유저 페이지에서 게시물 수 연동 완료
> UserPage 에서 postCount를 props로 내려줌. UserPostGrid 에서 post 를 불러오고 setter로 count를 설정. UserInfo 에선 설정된 postCount 를 출력

### 스크린샷 (선택)
<img width="502" height="884" alt="image" src="https://github.com/user-attachments/assets/8c74b016-5e4e-445c-8e06-45e236f284c9" />
