### PR TITLE
Feat/user 유저 뱃지 변경 (#34)

### DIFF
--- a/front/src/components/common/LoginForm.jsx
+++ b/front/src/components/common/LoginForm.jsx
@@ -24,7 +24,10 @@ const LoginForm = () => {
       })
       .then((response) => {
         console.log("로그인 성공:", response);
-        navigate("/");
+        if (response.data.role === "ADMIN")
+          navigate("/admin");
+        else
+          navigate("/");
       })
       .catch(() => {
         alert("오류입니다!");

--- a/front/src/components/user/UserInfo.jsx
+++ b/front/src/components/user/UserInfo.jsx
@@ -11,29 +11,14 @@ import { Dropdown } from "antd";
 import { EllipsisOutlined } from "@ant-design/icons";
 import ReportModal from "../common/ReportModal";
 
-function UserInfo({ user, postCount, isBlocked, setIsBlocked }) {
+function UserInfo({ user, postCount, isBlocked, setIsBlocked, isFollowing, setIsFollowing }) {
   const nav = useNavigate();
-  const [isFollowing, setIsFollowing] = useState(false);
   const [followerCount, setFollowerCount] = useState(user.followerCount);
   const [reportOpen, setReportOpen] = useState(false);
 
   useEffect(() => {
-    if (user.isMe) return;
-    if (!user.userId) return;
-
-    axiosInstance({
-      url: `/api/follow/${user.userId}`,
-      method: "GET",
-    })
-      .then((res) => {
-        //console.log("result: ", res);
-        setIsFollowing(res.data);
-        setFollowerCount(user.followerCount);
-      })
-      .catch(() => {
-        alert("팔로우 조회 실패");
-      });
-  }, [user.userId]);
+    setFollowerCount(user.followerCount);
+  }, [user]);
 
   const follow = () => {
     axiosInstance({
@@ -44,12 +29,12 @@ function UserInfo({ user, postCount, isBlocked, setIsBlocked }) {
       },
     })
       .then((res) => {
-        //console.log("result: ", res);
-        setIsFollowing(true);
+        console.log("result: ", res);
+        setIsFollowing(res.data);
         setFollowerCount((cnt) => cnt + 1);
       })
       .catch(() => {
-        alert("팔로우 실패");
+        alert("이미 팔로우 요청을 보냈습니다.");
       });
   };
 
@@ -158,7 +143,7 @@ function UserInfo({ user, postCount, isBlocked, setIsBlocked }) {
         <div className="profile-right">
           <h2 className="username-row">
             <span className="username">
-              {user.username}
+              {user.username} &nbsp;
               <Badge imageUrl={user.customDTO?.badgeDTO?.imageUrl} />
             </span>
 
@@ -200,7 +185,7 @@ function UserInfo({ user, postCount, isBlocked, setIsBlocked }) {
         ) : (
           <>
             {isFollowing ? 
-              <ProfileButton btnType="point" onClick={unfollow}>팔로우 중</ProfileButton>
+              <ProfileButton btnType="default" onClick={unfollow}>팔로우 중</ProfileButton>
               :
               <ProfileButton btnType="point" onClick={follow}>팔로우</ProfileButton>
             }

--- a/front/src/components/user/UserPostGrid.jsx
+++ b/front/src/components/user/UserPostGrid.jsx
@@ -51,7 +51,7 @@ function UserPostGrid({ user, onPostCountChange, isBlocked, isFollowing }) {
     )
   }
 
-  if (!isFollowing && user.isPrivate) {
+  if (!isFollowing && user.isPrivate && !user.isMe) {
     return (
       <div className="post-grid">
         <div className="no-posts">비공개 유저입니다.</div>

--- a/front/src/components/user/UserPostGrid.jsx
+++ b/front/src/components/user/UserPostGrid.jsx
@@ -4,20 +4,20 @@ import "./UserPostGrid.css";
 import { useNavigate } from "react-router-dom";
 import PostDetailView from "../post/PostDetailView";
 
-function UserPostGrid({ userId, onPostCountChange, isBlocked }) {
+function UserPostGrid({ user, onPostCountChange, isBlocked, isFollowing }) {
   const [posts, setPosts] = useState([]);
   const [modalOpen, setModalOpen] = useState(false);
   const [postId, setPostId] = useState(0);
   const nav = useNavigate();
 
   useEffect(() => {
-    if (!userId) return;
+    if (!user.userId) return;
 
     axiosInstance({
       url: `/api/posts/getPostsByUserId`,
       method: "get",
       params: {
-        userId,
+        userId: user.userId,
         pageNo: 1,
       },
     })
@@ -36,7 +36,7 @@ function UserPostGrid({ userId, onPostCountChange, isBlocked }) {
           alert("게시물을 불러오지 못했습니다.");
         }
       });
-  }, [userId]);
+  }, [user]);
 
   const onClick = (e) => {
     setModalOpen(true);
@@ -47,6 +47,14 @@ function UserPostGrid({ userId, onPostCountChange, isBlocked }) {
     return (
       <div className="post-grid">
         <div className="no-posts">차단한 유저입니다.</div>
+      </div>
+    )
+  }
+
+  if (!isFollowing && user.isPrivate) {
+    return (
+      <div className="post-grid">
+        <div className="no-posts">비공개 유저입니다.</div>
       </div>
     )
   }

--- a/front/src/pages/user/BadgeSettings.jsx
+++ b/front/src/pages/user/BadgeSettings.jsx
@@ -34,6 +34,20 @@ function BadgeSettings() {
     }
   };
 
+  const changeBadge = (id, name) => {
+    if (!confirm(name + "(으)로 뱃지를 바꾸시겠습니까?")) return;
+    axiosInstance({
+      url: `/api/user/custom/BADGE/${id}`,
+      method: "PUT",
+    })
+      .then(() => {
+        alert("뱃지 변경 완료!");
+      })
+      .catch(() => {
+        alert("뱃지 변경을 실패했습니다.");
+      });
+  }
+
   if (loading) {
     return (
       <Container>
@@ -61,7 +75,7 @@ function BadgeSettings() {
       ) : (
         <BadgeGrid>
           {myBadges.map((badge) => (
-            <BadgeCard key={badge.badgeId}>
+            <BadgeCard key={badge.badgeId} onClick={() => changeBadge(badge.badgeId, badge.name)}>
               <BadgeImage src={badge.imageUrl} alt={badge.name} />
               <BadgeName>{badge.name}</BadgeName>
               <BadgeDescription>{badge.description}</BadgeDescription>

--- a/front/src/pages/user/UserPage.jsx
+++ b/front/src/pages/user/UserPage.jsx
@@ -11,6 +11,7 @@ function UserPage() {
   const nav = useNavigate();
   const loginUser = useSelector((state) => state.auth.user);
   const [postCount, setPostCount] = useState(0);
+  const [isFollowing, setIsFollowing] = useState(false);
   const [isBlocked, setIsBlocked] = useState(false);
 
   const [user, setUser] = useState({
@@ -35,7 +36,7 @@ function UserPage() {
     })
       .then((result) => {
         setUser(result.data);
-        console.log("user: ", user);
+        //console.log("user: ", user);
     })
       .catch((err) => {
         //console.log(err);
@@ -57,6 +58,18 @@ function UserPage() {
       .catch(() => {
         console.error("차단 상태 조회 실패");
       });
+    
+    axiosInstance({
+      url: `/api/follow/${id}`,
+      method: "GET",
+    })
+      .then((res) => {
+        //console.log("result: ", res);
+        setIsFollowing(res.data);
+      })
+      .catch(() => {
+        alert("팔로우 조회 실패");
+      });
   }, [id, loginUser]);
 
   const targetUser = id ? user : loginUser;
@@ -65,8 +78,11 @@ function UserPage() {
   return (
     <>
       <UserHeader user={targetUser} />
-      <UserInfo user={targetUser} postCount={postCount} isBlocked={isBlocked} setIsBlocked={setIsBlocked} />
-      <UserPostGrid userId={targetUser.userId} onPostCountChange={setPostCount} isBlocked={isBlocked} />
+      <UserInfo user={targetUser} postCount={postCount} 
+        isBlocked={isBlocked} setIsBlocked={setIsBlocked}
+        isFollowing={isFollowing} setIsFollowing={setIsFollowing} />
+      <UserPostGrid user={targetUser} onPostCountChange={setPostCount} 
+        isBlocked={isBlocked} isFollowing={isFollowing} />
     </>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #34(비공개 유저 페이지), #37(유저 설정 페이지 - 뱃지 변경)

## 📝작업 내용

- 비공개 유저일 시 유저 페이지에서 "비공개 유저입니다"
- 유저 설정 페이지에서 뱃지 변경

### 스크린샷 (선택)
1. 비공개 유저
<img width="251" height="844284" alt="image" src="https://github.com/user-attachments/assets/55c01182-df1a-46f2-9895-9314a437edf1" />

2. 뱃지 변경
<img width="251" height="442" alt="image" src="https://github.com/user-attachments/assets/1aff241e-cfba-42c8-9772-7d785d317482" /><img width="251" height="442" alt="image" src="https://github.com/user-attachments/assets/1bbc3e6e-b46b-4f08-a15c-7901122d6138" /><img width="251" height="442" alt="image" src="https://github.com/user-attachments/assets/1cb57f77-790d-439a-a43c-8acfec7f41c4" />


(비공개 유저를 팔로우 시에 팔로우 버튼은 변하지 않지만 팔로우 요청은 들어간 상태....하지만 팔로우 수락은 없다는 무서운 이야기.. 아마 알림 쪽에서 알림 + 우측에 수락/거절 버튼을 만들어준다면 백과 연결은 쉬울 것....)
(뱃지 없음...선택은 아직...없다..)
